### PR TITLE
Pose net singlepose p5 image

### DIFF
--- a/src/PoseNet/index.js
+++ b/src/PoseNet/index.js
@@ -111,11 +111,16 @@ class PoseNet extends EventEmitter {
     let input;
     if (inputOr instanceof HTMLImageElement || inputOr instanceof HTMLVideoElement) {
       input = inputOr;
-    } else if (typeof inputOr === 'object' && (inputOr.elt instanceof HTMLImageElement || inputOr.elt instanceof HTMLVideoElement)) {
-      input = inputOr.elt; // Handle p5.js image and video
+    } else if (typeof inputOr === "object") {
+      if (!inputOr.pixels.length) {
+        inputOr.loadPixels();
+      }
+      // Handle p5.js image
+      input = inputOr.imageData;
     } else {
       input = this.video;
     }
+    
 
     const pose = await this.net.estimateSinglePose(input, this.imageScaleFactor, this.flipHorizontal, this.outputStride);
     const poseWithParts = this.mapParts(pose);


### PR DESCRIPTION
## → Description 📝

bug 🐛

I have changed the singlePose function in order to handle p5 Image types. 
I'm not sure why we previously were checking for instance type equality with HTMLImageElement or HTMLVideoElement to determine if the type was of p5.Image.

## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄

Here's an example. In order for this to work, you will need any image called 'runner.jpg' in a folder called 'images' in the root of the example.

```
 let img;
      let poseNet;
      let poses = [];
      function setup() {
        createCanvas(640, 360);
        img = loadImage("images/runner.jpg", onImageReady);
      }

      function onImageReady() {
        poseNet = ml5.poseNet(onModelReady);
      }

      function onModelReady() {
        poseNet.on("pose", function(results) {
          console.log(results);
        });
        poseNet.singlePose(img);
      }
```


## → Relevant documentation 🌴
This fix doesn't change the current API


